### PR TITLE
Remove duplicate esbuild config from package.json

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -659,7 +659,6 @@
     "dbinfoz": "^0.14.0",
     "diff": "^7.0.0",
     "downshift": "^7.6.0",
-    "esbuild": "0.17.19",
     "express": "^4.18.2",
     "fkill": "^8.1.0",
     "follow-redirects": "^1.15.4",


### PR DESCRIPTION
## Description
Test if removing esbuild from `dependencies` (while keeping it in `devDependencies` as per documentation) will make the esbuild.js honor the exclusion of said module from the final .vsix package

[ What changed? Feel free to be brief. ]

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
